### PR TITLE
Only remove autonumeric if defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ export default class ReactNumeric extends React.Component {
     });
   }
   componentWillUnmount() {
-    this.autonumeric.remove();
+    if (this.autonumeric) this.autonumeric.remove();
   }
 
   componentWillReceiveProps(newProps) {


### PR DESCRIPTION
I don't imagine this has a large incidence rate, but we've seen some cases where `autonumeric` isn't defined which raises error noise.

This patch just adds a check to prevent removal of it when it isn't there.